### PR TITLE
Update QAOA procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,15 @@ Note that the PennyLane dependency is installed from a development branch contai
 
 Additionally, if running the notebook `exact_costs.ipynb`, this will require an additional installation of the code available in this [repository](https://github.com/Matematija/QubitRBM) that is not included in the requirements.
 
-### Authors
-
-Angus Lowe, Matija Medvidovi&#263;, Anthony Hayes, Lee J. O’Riordan, Thomas R. Bromley, Juan Miguel Arrazola, and Nathan Killoran
+### Original paper
 
 If you are doing any research using this source code, please cite the following paper:
 
 > Angus Lowe, Matija Medvidovi&#263;, Anthony Hayes, Lee J. O’Riordan, Thomas R. Bromley, Juan Miguel Arrazola, and Nathan Killoran. _Fast quantum circuit cutting with randomized measurements_. [arXiv:2207.14734](https://arxiv.org/abs/2207.14734) (2022).
+
+### Contributors (alphabetical order)
+
+Thomas R. Bromley, Amintor Dusko, Anthony Hayes, Nathan Killoran, Angus Lowe, Matija Medvidovi&#263;, Juan Miguel Arrazola, and Lee J. O’Riordan.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p float="left">
   <img src="./static/shots_vs_cost_left.png" width="300" />
-  <img src="./static/shots_vs_cost_right.png" width="300" /> 
+  <img src="./static/shots_vs_cost_right.png" width="300" />
 </p>
 
 - Large scale QAOA simulations using circuit cutting methods executed over multiple GPUs.
@@ -16,18 +16,18 @@
 
 <p float="left">
   <img src="./static/multi_opt.png" width="300" />
-  <img src="./static/scaling_vs_gpu_nodes.png" width="300" /> 
+  <img src="./static/scaling_vs_gpu_nodes.png" width="300" />
 </p>
 
 ### Contents
 
-- `optimize.py`: Python script for performing full QAOA distributed over multiple GPUs using circuit cutting methods. This was used to produce the results in the accompanying paper.
+- `optimize.py`: Python script for performing full QAOA distributed over multiple GPUs/CPUs using circuit cutting methods, and native pennylane differentiation methods.
 
 - `forward_pass.py`: Python script for executing forward passes of QAOA circuits (no gradients/optimization) distributed over multiple GPUs using circuit cutting methods.
 
 - `exact_costs.ipynb`: Jupyter notebook for analysis of exact cost values of single layer QAOA circuits. This uses results from this [paper](https://arxiv.org/pdf/2009.01760.pdf) and the accompanying [repository](https://github.com/Matematija/QubitRBM)
 
-- `utils.py`: Python script containing utility functions for constructing problem graphs to be input to QAOA for Max-Cut and building the corresponding quantum circuit. 
+- `utils.py`: Python script containing utility functions for constructing problem graphs to be input to QAOA for Max-Cut and building the corresponding quantum circuit.
 
 - `data/`: Folder containing example output logs generated from above scripts. This data was used to generate the plots in the accompanying paper.
 
@@ -66,17 +66,23 @@ You can also visit [pennylane.xanadu.ai](https://pennylane.xanadu.ai) to run not
 
 ### Requirements
 
-All software requirements for running the provided python scripts can be installed by running the following command from the top level directory: 
+All software requirements for running the provided python scripts on GPUS can be installed by running the following command from the top level directory:
 
 ```
 $ pip install -r requirements.txt
 ```
 
-This requires [`pip`](https://pip.pypa.io/en/stable/installation/)  to be installed on your machine. 
+For running on CPUs:
 
-We also recommend the use of a virtual environment (e.g [`venv`](https://docs.python.org/3/library/venv.html)) when installing these requirements. 
+```
+$ pip install -r requirements-lightning.txt
+```
 
-Note that the PennyLane dependency is installed from a development branch containing the necessary updates to perform efficient measurements of the cost Hamiltonians used in the QAOA circuit simulations. 
+This requires [`pip`](https://pip.pypa.io/en/stable/installation/)  to be installed on your machine.
+
+We also recommend the use of a virtual environment (e.g [`venv`](https://docs.python.org/3/library/venv.html)) when installing these requirements.
+
+Note that the PennyLane dependency is installed from a development branch containing the necessary updates to perform efficient measurements of the cost Hamiltonians used in the QAOA circuit simulations.
 
 Additionally, if running the notebook `exact_costs.ipynb`, this will require an additional installation of the code available in this [repository](https://github.com/Matematija/QubitRBM) that is not included in the requirements.
 

--- a/optimize.py
+++ b/optimize.py
@@ -111,7 +111,7 @@ def _execute_tape_jac(tape, device_name, frag_wires):
     return dev.adjoint_jacobian(tape)
 
 def execute_tape_jac(_num_gpus):
-    if (_num_gpus == None):
+    if (_num_gpus == None) or (_num_gpus == 0):
         return ray.remote(_execute_tape_jac)
     else:
         return ray.remote(num_gpus=_num_gpus, max_calls=1)(_execute_tape_jac)

--- a/optimize.py
+++ b/optimize.py
@@ -13,6 +13,9 @@ import ray
 seed = 1967
 
 
+########################################################################
+# Parsing arguments
+########################################################################
 def parse_args():
     parser = argparse.ArgumentParser()
 
@@ -94,7 +97,7 @@ def find_depth(tapes):
 
 
 ########################################################################
-# Execute methods
+# Execute method
 ########################################################################
 def _execute_tape(tape, device_name, frag_wires):
     dev = qml.device(device_name, wires=frag_wires)
@@ -109,6 +112,9 @@ def execute_tape(_num_gpus):
         return ray.remote(num_gpus=_num_gpus, max_calls=1)(_execute_tape)
 
 
+########################################################################
+# Cost Value
+########################################################################
 def QAOA_cost(args, frag_wires, params):
     """
     Executes the QAOA circuit for a given set of parameters and returns a cost value.
@@ -154,7 +160,7 @@ def QAOA_cost(args, frag_wires, params):
 
 
 ########################################################################
-# Gradients
+# Gradient calculation
 ########################################################################
 def execute_grad(params, args, frag_wires, graph_data):
     """
@@ -206,6 +212,9 @@ def execute_grad(params, args, frag_wires, graph_data):
     )
 
 
+########################################################################
+# Gradient descent procedure
+########################################################################
 def grad_descent(steps, args, frag_wires, graph_data):
     """
     Function to perform gradient descent

--- a/optimize.py
+++ b/optimize.py
@@ -78,6 +78,14 @@ def parse_args():
         help="Number of gpus per tape execution (can be fractional). Set as zero for cpu only.",
     )  # gpu control
 
+    # Optimization steps
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=2,
+        help="Number of steps in the optimization procedure.",
+    )
+
     return parser.parse_args()
 
 
@@ -212,7 +220,7 @@ def execute_grad(params, args, frag_wires, graph_data):
 ########################################################################
 # Gradient descent procedure
 ########################################################################
-def grad_descent(steps, args, frag_wires, graph_data):
+def grad_descent(args, frag_wires, graph_data):
     """
     Function to perform gradient descent
     """
@@ -235,15 +243,15 @@ def grad_descent(steps, args, frag_wires, graph_data):
     params = init_params
     start_opt = timer()
 
-    for i in range(steps):
+    for i in range(args.steps):
         print(f"\n=====================================")
-        print(f"Step {i+1}/{steps}:")
+        print(f"Step {i+1}/{args.steps}:")
         print(f"Number of params = {params.size}", flush=True)
         cost = QAOA_cost(params, args, frag_wires, graph_data)
         print(f"Cost at step {i} = {cost}", flush=True)
         grad = execute_grad(params, args, frag_wires, graph_data)
         print(f"Grad len = {len(grad)}", flush=True)
-        params -= 0.0001 * grad
+        params -= 0.001 * grad
     print(f"=====================================")
 
     print(f"\nFinal report:", flush=True)
@@ -299,4 +307,4 @@ if __name__ == "__main__":
     )
     graph_data = dict(G=G, cluster_nodes=cluster_nodes, separator_nodes=separator_nodes)
 
-    grad_descent(steps=1, args=args, frag_wires=frag_wires, graph_data=graph_data)
+    grad_descent(args=args, frag_wires=frag_wires, graph_data=graph_data)

--- a/optimize.py
+++ b/optimize.py
@@ -67,7 +67,7 @@ def parse_args():
         "--intra_cluster_edge_prob",
         type=float,
         default=0.7,
-        help="Probability of having an intra cluster edge.",
+        help="Probability of having an intra-cluster edge.",
     )  # q1
 
     return parser.parse_args()

--- a/optimize.py
+++ b/optimize.py
@@ -2,7 +2,6 @@ import sys
 import argparse
 import pennylane as qml
 from pennylane import numpy as np
-import torch
 from timeit import default_timer as timer
 from datetime import datetime, timedelta
 

--- a/optimize.py
+++ b/optimize.py
@@ -115,19 +115,17 @@ def execute_tape(_num_gpus):
 ########################################################################
 # Cost Value
 ########################################################################
-def QAOA_cost(args, frag_wires, params):
+def QAOA_cost(params, args, frag_wires, graph_data):
     """
     Executes the QAOA circuit for a given set of parameters and returns a cost value.
     """
-    G, cluster_nodes, separator_nodes = clustered_chain_graph(
-        args.nodes_per_cluster,
-        args.num_clusters,
-        args.vertex_separators,
-        args.intra_cluster_edge_prob,
-        1 - args.intra_cluster_edge_prob,
-        seed=seed,
+    circuit = get_qaoa_circuit(
+        graph_data["G"],
+        graph_data["cluster_nodes"],
+        graph_data["separator_nodes"],
+        params,
+        args.layers,
     )
-    circuit = get_qaoa_circuit(G, cluster_nodes, separator_nodes, params, args.layers)
 
     start_frag = timer()
 
@@ -242,7 +240,7 @@ def grad_descent(steps, args, frag_wires, graph_data):
         print(f"\n=====================================")
         print(f"Step {i+1}/{steps}:")
         print(f"Number of params = {params.size}", flush=True)
-        cost = QAOA_cost(args, frag_wires, params)
+        cost = QAOA_cost(params, args, frag_wires, graph_data)
         print(f"Cost at step {i} = {cost}", flush=True)
         grad = execute_grad(params, args, frag_wires, graph_data)
         print(f"Grad len = {len(grad)}", flush=True)

--- a/requirements-lightning.txt
+++ b/requirements-lightning.txt
@@ -2,4 +2,3 @@ git+https://github.com/PennyLaneAI/pennylane.git@qcut_multiple_paulis
 PennyLane-Lightning~=0.26.0
 ray==1.13
 networkx==2.8
-torch==1.12

--- a/requirements-lightning.txt
+++ b/requirements-lightning.txt
@@ -1,0 +1,5 @@
+git+https://github.com/PennyLaneAI/pennylane.git@qcut_multiple_paulis
+PennyLane-Lightning~=0.26.0
+ray==1.13
+networkx==2.8
+torch==1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-PennyLane @ git+https://github.com/PennyLaneAI/pennylane@09f02c8c043b0461c2e805a639e1a4e7cd534ed1
+git+https://github.com/PennyLaneAI/pennylane.git@qcut_multiple_paulis
 PennyLane-Lightning-GPU==0.23.0
-ray==1.12.0
+ray==1.13
 networkx==2.8
-torch==1.11.0
+torch==1.12


### PR DESCRIPTION
The script on the `optimize.py` file was reviewed and refactored to run with pennylane native differentiation methods and other devices. Devices and differentiation methods can be set with the flags `--device_name` and `--diff_method`, respectively. Device options are ("lightning.qubit", "lightning.gpu", "lightning.kokkos", "default.qubit") and the differentiation method are  ("param_shift", "finite_diff"). The default values are `lightning.qubit` and `param_shift`.

### Other configuration labels are:
- `--layers`: Number of repetition layers. Default: 2
- `--num_clusters`: Number of graph nodes. Default: 2
- `--nodes_per_cluster`: Number of nodes within each cluster. Default: 2
- `--vertex_separators`: Vertex separators between each cluster. Default: 1
- `--intra_cluster_edge_prob`: Probability of having an intra-cluster edge. Default: 0.7

For controlling GPU usage:
- `--num_gpus`: Number of GPUs per tape execution (can be fractional). Default: 0.0
If zero, the script will run on the CPU only.

This information can be accessed at any point with: `python optimize.py --help`